### PR TITLE
chore(ci): prep node24-compatible workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,17 +29,17 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PYTHON_VERSION }}
         cache: 'pip'
         cache-dependency-path: backend/pyproject.toml
 
     - name: Cache uv dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cache/uv
@@ -117,15 +117,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Cache uv dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cache/uv
@@ -191,7 +191,7 @@ jobs:
           --increment=1
 
     - name: Upload backend reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       if: always()
       with:
         name: backend-reports
@@ -202,7 +202,7 @@ jobs:
         retention-days: 30
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         file: ./backend/coverage.xml
         flags: backend
@@ -242,15 +242,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Cache uv dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cache/uv
@@ -282,7 +282,7 @@ jobs:
         uv run pytest tests/e2e/ -m e2e --no-cov -v --junitxml=../test-results/backend/junit/junit-e2e.xml
 
     - name: Upload backend E2E reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       if: always()
       with:
         name: backend-e2e-reports
@@ -300,10 +300,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ env.NODE_VERSION }}
 
@@ -319,7 +319,7 @@ jobs:
         echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
     - name: Setup pnpm cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -369,7 +369,7 @@ jobs:
         pnpm type-coverage:check || true  # Non-blocking for now
 
     - name: Upload frontend lint reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       if: always()
       with:
         name: frontend-lint-reports
@@ -390,10 +390,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ env.NODE_VERSION }}
 
@@ -409,7 +409,7 @@ jobs:
         echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
     - name: Setup pnpm cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -446,7 +446,7 @@ jobs:
           --increment=1 || true  # Non-blocking until we reach baseline
 
     - name: Upload frontend reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       if: always()
       with:
         name: frontend-reports
@@ -456,7 +456,7 @@ jobs:
         retention-days: 30
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         file: ./test-results/frontend/coverage/lcov.info
         flags: frontend
@@ -469,7 +469,7 @@ jobs:
         npm run build
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: frontend-dist
         path: frontend/dist/
@@ -507,15 +507,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ env.NODE_VERSION }}
 
@@ -525,7 +525,7 @@ jobs:
         version: 10
 
     - name: Cache uv dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cache/uv
@@ -541,7 +541,7 @@ jobs:
         echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
     - name: Setup pnpm cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ steps.pnpm-cache-make.outputs.STORE_PATH }}
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -611,15 +611,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ env.NODE_VERSION }}
 
@@ -629,7 +629,7 @@ jobs:
         version: 10
 
     - name: Cache uv dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cache/uv
@@ -645,7 +645,7 @@ jobs:
         echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
     - name: Setup pnpm cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ steps.pnpm-cache-e2e.outputs.STORE_PATH }}
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -924,7 +924,7 @@ jobs:
         pnpm e2e:ci
 
     - name: Upload frontend E2E reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       if: always()
       with:
         name: frontend-e2e-reports
@@ -977,15 +977,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ env.NODE_VERSION }}
 
@@ -995,7 +995,7 @@ jobs:
         version: 10
 
     - name: Cache uv dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cache/uv
@@ -1011,7 +1011,7 @@ jobs:
         echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
     - name: Setup pnpm cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ steps.pnpm-cache-import-e2e.outputs.STORE_PATH }}
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -1213,7 +1213,7 @@ jobs:
         make test-e2e-import
 
     - name: Upload import E2E reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       if: always()
       with:
         name: import-e2e-reports
@@ -1240,15 +1240,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ env.NODE_VERSION }}
 
@@ -1352,15 +1352,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Cache uv dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cache/uv
@@ -1389,7 +1389,7 @@ jobs:
         # REMOVED || true - integration tests should pass on main branch
 
     - name: Upload integration test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       if: always()
       with:
         name: integration-reports
@@ -1409,7 +1409,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Download all reports
       uses: actions/download-artifact@v4

--- a/.github/workflows/quality-trends.yml
+++ b/.github/workflows/quality-trends.yml
@@ -13,17 +13,17 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0  # Full history for trends (完整历史用于趋势分析)
 
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
 
@@ -123,7 +123,7 @@ jobs:
     # Upload Reports
     # ===========================
     - name: Upload quality reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: weekly-quality-report-${{ github.run_number }}
         path: reports/

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
@@ -86,15 +86,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '20'
 
@@ -116,7 +116,7 @@ jobs:
         npm audit --audit-level=high || true
 
     - name: Upload dependency reports
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       if: always()
       with:
         name: dependency-security-reports
@@ -134,10 +134,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
@@ -157,7 +157,7 @@ jobs:
         bandit -r src/ -f txt || true
 
     - name: Upload Bandit report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       if: always()
       with:
         name: bandit-report
@@ -174,7 +174,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased] - 2026-03-06
 
 ### 2026-03-22
+- chore(ci): 升级 GitHub Actions 依赖到 Node 24 兼容大版本，收口 runner 弃用告警。`.github/workflows/ci.yml`、`.github/workflows/security.yml`、`.github/workflows/quality-trends.yml` 中的 `actions/checkout`、`actions/setup-python`、`actions/setup-node`、`actions/cache`、`actions/upload-artifact` 与 `codecov/codecov-action` 已从会触发 Node 20 弃用提示的旧大版本提升到新的兼容大版本；项目作业里安装的业务 Node 版本仍保持 20，不引入额外运行时漂移。新增回归：`backend/tests/unit/config/test_ci_workflow.py` 现在显式禁止这三条 workflow 再 pin 到旧的 Node 20 action major。验证待本轮 CI/workflow 定向校验补充。
+- docs(plans): 新增 `docs/plans/2026-03-22-perspective-simplification-v2-follow-up.md`，把“视角简化 v2”后续工作收敛为单一前端计划：以路由前缀替代 `ViewContext` / `viewSelectionStorage`，完成 owner/manager canonical route 收口、内部导航切换和 targeted E2E 回归；`docs/plans/README.md` 同步登记为 📋 待评审活跃方案。验证待本轮 docs 校验补充。
 - fix(frontend-nav): 修复视角前缀落地后仍从 legacy 路径起跑的剩余 active-path 漏口。`frontend/src/pages/PropertyCertificate/PropertyCertificateImport.tsx` 的导入成功跳转、`frontend/src/pages/PropertyCertificate/PropertyCertificateDetailPage.tsx` 的返回/删除成功跳转，现统一落到 active owner 列表 `/owner/property-certificates`，避免 capability 无 owner 绑定时再经过 legacy `/property-certificates` 被 `LegacyRouteRedirect` 打回 `/dashboard`；同时把 `frontend/tests/e2e/asset-flow.spec.ts`、`frontend/tests/e2e/user/user-usability.spec.ts`、`frontend/tests/e2e/user/import-guardrails.spec.ts` 的资产/项目/合同导入起跑路径切到 active route（`/owner/assets`、`/manager/projects`、`/contract-groups/import`），并收紧 `frontend/tests/e2e/helpers/auth.ts` 的 `clearAuthState()`，避免 webkit 在登录页重定向瞬间清理 storage 时触发 execution context destroyed。新增/扩展回归：`frontend/src/pages/PropertyCertificate/__tests__/PropertyCertificateImport.test.tsx` 锁定导入成功后的 owner 列表跳转。验证待本轮 hotfix 回归补充。
 
 ### 2026-03-21

--- a/backend/tests/unit/config/test_ci_workflow.py
+++ b/backend/tests/unit/config/test_ci_workflow.py
@@ -19,6 +19,11 @@ def _load_ci_workflow() -> dict[str, Any]:
     return yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
 
 
+def _load_workflow(workflow_name: str) -> dict[str, Any]:
+    workflow_path = _repo_root() / ".github" / "workflows" / workflow_name
+    return yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+
+
 def _job_steps(job: dict[str, Any]) -> Iterable[dict[str, Any]]:
     steps = job.get("steps")
     if isinstance(steps, list):
@@ -198,3 +203,42 @@ def test_frontend_e2e_seed_should_provision_non_admin_role() -> None:
 
     assert "ensure_regular_role" in seed_script
     assert 'Role.name == "user"' in seed_script
+
+
+def test_workflows_should_not_pin_deprecated_node20_action_majors() -> None:
+    deprecated_action_versions = {
+        "actions/checkout@v4",
+        "actions/setup-python@v4",
+        "actions/setup-node@v4",
+        "actions/cache@v4",
+        "actions/upload-artifact@v4",
+        "codecov/codecov-action@v4",
+    }
+    workflow_names = ("ci.yml", "security.yml", "quality-trends.yml")
+
+    deprecated_usage_by_workflow: dict[str, list[str]] = {}
+    for workflow_name in workflow_names:
+        workflow = _load_workflow(workflow_name)
+        jobs = workflow.get("jobs")
+        if not isinstance(jobs, dict):
+            continue
+
+        matched_uses: set[str] = set()
+        for job in jobs.values():
+            if not isinstance(job, dict):
+                continue
+
+            for step in _job_steps(job):
+                uses = step.get("uses")
+                if not isinstance(uses, str):
+                    continue
+                if uses in deprecated_action_versions:
+                    matched_uses.add(uses)
+
+        if matched_uses:
+            deprecated_usage_by_workflow[workflow_name] = sorted(matched_uses)
+
+    assert not deprecated_usage_by_workflow, (
+        "Workflows should not pin GitHub-hosted actions that still run on deprecated Node 20 "
+        f"majors: {deprecated_usage_by_workflow}"
+    )

--- a/docs/plans/2026-03-22-perspective-simplification-v2-follow-up.md
+++ b/docs/plans/2026-03-22-perspective-simplification-v2-follow-up.md
@@ -1,0 +1,443 @@
+# Frontend Perspective Simplification V2 Follow-up Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish converting the merged owner/manager route shell into the canonical frontend perspective model, so perspective is derived from the route instead of persisted manual view selection.
+
+**Architecture:** Keep backend authz and data scope unchanged. On the frontend, treat route prefix (`/owner/*`, `/manager/*`) as the only perspective signal, replace `ViewContext`/`viewSelectionStorage` with route-derived helpers, and move internal navigation to canonical active paths. Keep legacy redirects only as a short-lived migration shim until internal callers and tests are fully switched.
+
+**Tech Stack:** React 19, React Router 6, React Query 5, Vitest, Playwright, GitHub Actions
+
+---
+
+## Scope
+
+In scope:
+- route-derived perspective helper and query-scope keys
+- removal of manual view-selection storage/provider plumbing
+- canonical owner/manager internal navigation and tests
+- frontend unit/E2E coverage updates
+
+Out of scope:
+- backend authz rule redesign
+- capability package schema changes
+- party binding model changes
+- broad owner/manager data-scope semantics changes on the API side
+
+## Current Baseline
+
+- `OWNER_ROUTES` / `MANAGER_ROUTES` and `LegacyRouteRedirect` already exist.
+- `PartySelector` already infers default filter mode from `/owner/*` and `/manager/*`.
+- `ViewContext` still gates most assets/projects/analytics queries through `currentView`, `selectionRequired`, and `isViewReady`.
+- `queryScope.ts` still includes `viewSelectionStorage`, even though the selected view only affects frontend cache keys and loading gates.
+- Many page tests still mock `@/contexts/ViewContext`, which keeps the old mental model alive.
+
+## File Map
+
+### Create
+
+- `frontend/src/routes/perspective.ts`
+- `frontend/src/routes/__tests__/perspective.test.ts`
+
+### Modify
+
+- `frontend/src/App.tsx`
+- `frontend/src/constants/routes.ts`
+- `frontend/src/routes/AppRoutes.tsx`
+- `frontend/src/routes/LegacyRouteRedirect.tsx`
+- `frontend/src/utils/queryScope.ts`
+- `frontend/src/components/Common/PartySelector.tsx`
+- `frontend/src/components/Layout/AppBreadcrumb.tsx`
+- `frontend/src/components/Layout/AppSidebar.tsx`
+- `frontend/src/components/Layout/MobileMenu.tsx`
+- `frontend/src/components/Project/ProjectList.tsx`
+- `frontend/src/components/System/CurrentViewBanner.tsx`
+- `frontend/src/hooks/useAnalytics.ts`
+- `frontend/src/hooks/useAssetAnalytics.ts`
+- `frontend/src/hooks/useAssets.ts`
+- `frontend/src/hooks/useProject.ts`
+- `frontend/src/pages/Assets/AssetListPage.tsx`
+- `frontend/src/pages/Assets/AssetDetailPage.tsx`
+- `frontend/src/pages/Assets/AssetCreatePage.tsx`
+- `frontend/src/pages/Assets/AssetAnalyticsPage.tsx`
+- `frontend/src/pages/Project/ProjectDetailPage.tsx`
+- `frontend/src/pages/PropertyCertificate/PropertyCertificateDetailPage.tsx`
+- `frontend/src/pages/PropertyCertificate/PropertyCertificateImport.tsx`
+- `frontend/src/__tests__/app-view-provider.test.ts`
+- `frontend/src/components/Common/__tests__/PartySelector.test.tsx`
+- `frontend/src/components/Layout/__tests__/AppBreadcrumb.test.tsx`
+- `frontend/src/components/Layout/__tests__/AppSidebar.test.tsx`
+- `frontend/src/config/__tests__/menuConfig.perspective-grouping.test.tsx`
+- `frontend/src/config/__tests__/rental-retired-navigation.test.ts`
+- `frontend/src/hooks/__tests__/useAnalytics.test.ts`
+- `frontend/src/hooks/__tests__/useAssetAnalytics.test.ts`
+- `frontend/src/hooks/__tests__/useAssets.test.ts`
+- `frontend/src/hooks/__tests__/useProject.test.ts`
+- `frontend/src/pages/Assets/__tests__/AssetListPage.test.tsx`
+- `frontend/src/pages/Assets/__tests__/AssetDetailPage.test.tsx`
+- `frontend/src/pages/Assets/__tests__/AssetCreatePage.test.tsx`
+- `frontend/src/pages/Assets/__tests__/AssetAnalyticsPage.test.tsx`
+- `frontend/src/pages/Project/__tests__/ProjectDetailPage.test.tsx`
+- `frontend/src/components/Project/__tests__/ProjectList.test.tsx`
+- `frontend/tests/e2e/asset-flow.spec.ts`
+- `frontend/tests/e2e/user/user-usability.spec.ts`
+- `frontend/tests/e2e/user/import-guardrails.spec.ts`
+- `frontend/tests/e2e/user/property-certificate-import-success.spec.ts`
+- `CHANGELOG.md`
+
+### Delete
+
+- `frontend/src/contexts/ViewContext.tsx`
+- `frontend/src/utils/viewSelectionStorage.ts`
+- `frontend/src/types/viewSelection.ts`
+
+## Chunk 1: Route-Derived Perspective Core
+
+### Task 1: Introduce a single route perspective resolver
+
+**Files:**
+- Create: `frontend/src/routes/perspective.ts`
+- Test: `frontend/src/routes/__tests__/perspective.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { getRoutePerspective, isPerspectiveRoute } from '../perspective';
+
+describe('route perspective resolution', () => {
+  it('maps owner-prefixed paths to owner', () => {
+    expect(getRoutePerspective('/owner/assets')).toBe('owner');
+    expect(getRoutePerspective('/owner/property-certificates/cert-1')).toBe('owner');
+  });
+
+  it('maps manager-prefixed paths to manager', () => {
+    expect(getRoutePerspective('/manager/projects')).toBe('manager');
+    expect(getRoutePerspective('/manager/contract-groups/group-1')).toBe('manager');
+  });
+
+  it('returns null for shared and legacy paths', () => {
+    expect(getRoutePerspective('/dashboard')).toBeNull();
+    expect(getRoutePerspective('/assets/list')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && pnpm vitest run src/routes/__tests__/perspective.test.ts`
+Expected: FAIL because `perspective.ts` does not exist yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+export type RoutePerspective = 'owner' | 'manager' | null;
+
+export const getRoutePerspective = (pathname: string): RoutePerspective => {
+  if (pathname.startsWith('/owner/')) return 'owner';
+  if (pathname.startsWith('/manager/')) return 'manager';
+  return null;
+};
+
+export const isPerspectiveRoute = (pathname: string): boolean =>
+  getRoutePerspective(pathname) != null;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && pnpm vitest run src/routes/__tests__/perspective.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/routes/perspective.ts frontend/src/routes/__tests__/perspective.test.ts
+git commit -m "test(frontend-perspective): add route perspective resolver"
+```
+
+### Task 2: Collapse query scope to user + route perspective
+
+**Files:**
+- Modify: `frontend/src/utils/queryScope.ts`
+- Delete: `frontend/src/utils/viewSelectionStorage.ts`
+- Delete: `frontend/src/types/viewSelection.ts`
+- Test: `frontend/src/hooks/__tests__/useAssets.test.ts`
+- Test: `frontend/src/hooks/__tests__/useProject.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add assertions that query keys depend on route perspective, not stored view keys:
+
+```ts
+expect(result.current.queryKey).toEqual([
+  'assets-list',
+  'user:test-user|perspective:owner',
+  params,
+]);
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && pnpm vitest run src/hooks/__tests__/useAssets.test.ts src/hooks/__tests__/useProject.test.ts`
+Expected: FAIL because `queryScope.ts` still emits `view:<stored-key>`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+export type QueryScopePerspective = 'owner' | 'manager' | null;
+
+export const buildQueryScopeKey = (perspective: QueryScopePerspective): string => {
+  const currentUser = AuthStorage.getCurrentUser();
+  const normalizedPerspective = perspective == null ? 'perspective:none' : `perspective:${perspective}`;
+  return `${normalizeUserScope(currentUser?.id)}|${normalizedPerspective}`;
+};
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd frontend && pnpm vitest run src/hooks/__tests__/useAssets.test.ts src/hooks/__tests__/useProject.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/utils/queryScope.ts frontend/src/hooks/__tests__/useAssets.test.ts frontend/src/hooks/__tests__/useProject.test.ts
+git rm frontend/src/utils/viewSelectionStorage.ts frontend/src/types/viewSelection.ts
+git commit -m "refactor(frontend-perspective): drop stored view cache scope"
+```
+
+## Chunk 2: Remove ViewProvider Runtime Dependency
+
+### Task 3: Replace `useView()` consumers with route-derived state
+
+**Files:**
+- Modify: `frontend/src/hooks/useAnalytics.ts`
+- Modify: `frontend/src/hooks/useAssetAnalytics.ts`
+- Modify: `frontend/src/hooks/useAssets.ts`
+- Modify: `frontend/src/hooks/useProject.ts`
+- Modify: `frontend/src/pages/Assets/AssetListPage.tsx`
+- Modify: `frontend/src/pages/Assets/AssetDetailPage.tsx`
+- Modify: `frontend/src/pages/Assets/AssetCreatePage.tsx`
+- Modify: `frontend/src/pages/Assets/AssetAnalyticsPage.tsx`
+- Modify: `frontend/src/components/Project/ProjectList.tsx`
+- Modify: `frontend/src/pages/Project/ProjectDetailPage.tsx`
+- Test: `frontend/src/hooks/__tests__/useAnalytics.test.ts`
+- Test: `frontend/src/hooks/__tests__/useAssetAnalytics.test.ts`
+- Test: `frontend/src/pages/Assets/__tests__/AssetListPage.test.tsx`
+- Test: `frontend/src/pages/Assets/__tests__/AssetDetailPage.test.tsx`
+- Test: `frontend/src/pages/Assets/__tests__/AssetCreatePage.test.tsx`
+- Test: `frontend/src/pages/Assets/__tests__/AssetAnalyticsPage.test.tsx`
+- Test: `frontend/src/components/Project/__tests__/ProjectList.test.tsx`
+- Test: `frontend/src/pages/Project/__tests__/ProjectDetailPage.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Change tests to stop mocking `@/contexts/ViewContext` and instead mount inside a `MemoryRouter` with owner/manager paths. Assert:
+- owner route queries use `perspective:owner`
+- manager route queries use `perspective:manager`
+- shared routes stay queryable without manual selector blocking
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+`cd frontend && pnpm vitest run src/hooks/__tests__/useAnalytics.test.ts src/hooks/__tests__/useAssetAnalytics.test.ts src/pages/Assets/__tests__/AssetListPage.test.tsx src/pages/Assets/__tests__/AssetDetailPage.test.tsx src/pages/Assets/__tests__/AssetCreatePage.test.tsx src/pages/Assets/__tests__/AssetAnalyticsPage.test.tsx src/components/Project/__tests__/ProjectList.test.tsx src/pages/Project/__tests__/ProjectDetailPage.test.tsx`
+
+Expected: FAIL because components/hooks still import `useView()`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Implementation rules:
+- add a lightweight route helper or hook (for example `useRoutePerspective`) built on `useLocation()`
+- remove `isViewReady` gates from route-owned pages
+- keep route perspective only for cache scoping and owner/manager UI defaults
+- do not reintroduce selector-open or persisted localStorage state
+
+Illustrative hook:
+
+```ts
+export const useRoutePerspective = () => {
+  const { pathname } = useLocation();
+  const perspective = getRoutePerspective(pathname);
+  return {
+    perspective,
+    isPerspectiveRoute: perspective != null,
+  };
+};
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run the same vitest pack again.
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/hooks frontend/src/pages/Assets frontend/src/pages/Project frontend/src/components/Project
+git commit -m "refactor(frontend-perspective): derive page scope from route"
+```
+
+### Task 4: Remove `ViewProvider` and retire the banner plumbing
+
+**Files:**
+- Modify: `frontend/src/App.tsx`
+- Delete: `frontend/src/contexts/ViewContext.tsx`
+- Modify: `frontend/src/components/System/CurrentViewBanner.tsx`
+- Test: `frontend/src/__tests__/app-view-provider.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Update the app shell test to assert:
+- `App.tsx` no longer imports `ViewProvider`
+- `AuthProvider` wraps `AntdApp` directly
+- `CurrentViewBanner` renders route-derived labels or is removed from layout intentionally
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd frontend && pnpm vitest run src/__tests__/app-view-provider.test.ts`
+Expected: FAIL because `ViewProvider` is still imported and wrapped.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```tsx
+<AuthProvider>
+  <AntdApp>
+    <AppInitializer>
+      <BrowserRouter>{/* ... */}</BrowserRouter>
+    </AppInitializer>
+  </AntdApp>
+</AuthProvider>
+```
+
+If `CurrentViewBanner` stays, rewrite it to use route-derived labels only:
+
+```tsx
+if (perspective === 'owner') return <Alert description="业主视角" ... />;
+if (perspective === 'manager') return <Alert description="经营视角" ... />;
+return null;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+- `cd frontend && pnpm vitest run src/__tests__/app-view-provider.test.ts`
+- `cd frontend && pnpm type-check`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/App.tsx frontend/src/components/System/CurrentViewBanner.tsx frontend/src/__tests__/app-view-provider.test.ts
+git rm frontend/src/contexts/ViewContext.tsx
+git commit -m "refactor(frontend-perspective): remove ViewProvider runtime"
+```
+
+## Chunk 3: Canonical Navigation and Redirect Retirement
+
+### Task 5: Move all internal links to canonical owner/manager paths
+
+**Files:**
+- Modify: `frontend/src/constants/routes.ts`
+- Modify: `frontend/src/routes/AppRoutes.tsx`
+- Modify: `frontend/src/routes/LegacyRouteRedirect.tsx`
+- Modify: `frontend/src/components/Layout/AppBreadcrumb.tsx`
+- Modify: `frontend/src/components/Layout/AppSidebar.tsx`
+- Modify: `frontend/src/components/Layout/MobileMenu.tsx`
+- Modify: `frontend/src/pages/PropertyCertificate/PropertyCertificateDetailPage.tsx`
+- Modify: `frontend/src/pages/PropertyCertificate/PropertyCertificateImport.tsx`
+- Test: `frontend/src/components/Layout/__tests__/AppBreadcrumb.test.tsx`
+- Test: `frontend/src/components/Layout/__tests__/AppSidebar.test.tsx`
+- Test: `frontend/src/config/__tests__/menuConfig.perspective-grouping.test.tsx`
+- Test: `frontend/src/config/__tests__/rental-retired-navigation.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add/adjust assertions that:
+- menus never navigate to `/assets/list`, `/project`, `/property-certificates`
+- breadcrumbs resolve detail back-links to canonical `/owner/*` or `/manager/*` pages
+- `LegacyRouteRedirect` only remains for explicit legacy-entry compatibility, not internal navigation
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+`cd frontend && pnpm vitest run src/components/Layout/__tests__/AppBreadcrumb.test.tsx src/components/Layout/__tests__/AppSidebar.test.tsx src/config/__tests__/menuConfig.perspective-grouping.test.tsx src/config/__tests__/rental-retired-navigation.test.ts`
+
+Expected: FAIL until links and menus stop pointing at legacy shared routes.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Rules:
+- internal navigation from menus/buttons/breadcrumbs must target canonical owner/manager routes only
+- keep `LegacyRouteRedirect` for a bounded list of direct legacy URLs during the migration window
+- after all internal callers are switched, reduce `LegacyRouteRedirect` to explicit compatibility paths only
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run the same vitest pack again.
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/constants/routes.ts frontend/src/routes/AppRoutes.tsx frontend/src/routes/LegacyRouteRedirect.tsx frontend/src/components/Layout
+git commit -m "refactor(frontend-nav): canonicalize internal perspective routes"
+```
+
+### Task 6: Update E2E and finish fail-fast legacy exposure
+
+**Files:**
+- Modify: `frontend/tests/e2e/asset-flow.spec.ts`
+- Modify: `frontend/tests/e2e/user/user-usability.spec.ts`
+- Modify: `frontend/tests/e2e/user/import-guardrails.spec.ts`
+- Modify: `frontend/tests/e2e/user/property-certificate-import-success.spec.ts`
+
+- [ ] **Step 1: Write or update failing E2E expectations**
+
+Target assertions:
+- assets start from `/owner/assets`
+- projects start from `/manager/projects`
+- contract import starts from `/contract-groups/import`
+- property certificate success flows land on `/owner/property-certificates`
+
+- [ ] **Step 2: Run targeted E2E to verify failures**
+
+Run:
+`cd frontend && BASE_URL=http://127.0.0.1:5173 VITE_API_BASE_URL=http://127.0.0.1:8002/api/v1 E2E_ADMIN_USERNAME=admin E2E_ADMIN_PASSWORD='Admin123!@#' E2E_REQUIRE_AUTH_STATE=true pnpm playwright test tests/e2e/asset-flow.spec.ts tests/e2e/user/property-certificate-import-success.spec.ts tests/e2e/user/user-usability.spec.ts tests/e2e/user/import-guardrails.spec.ts --project=chromium`
+
+Expected: FAIL until all route expectations and in-app navigations are canonical.
+
+- [ ] **Step 3: Write minimal implementation / spec updates**
+
+Update only the spec expectations and any remaining in-app navigation that still lands on shared legacy paths. Do not weaken assertions; point them at canonical active paths.
+
+- [ ] **Step 4: Run targeted E2E to verify it passes**
+
+Run the same Playwright command again.
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/tests/e2e/asset-flow.spec.ts frontend/tests/e2e/user/user-usability.spec.ts frontend/tests/e2e/user/import-guardrails.spec.ts frontend/tests/e2e/user/property-certificate-import-success.spec.ts
+git commit -m "test(frontend-perspective): align canonical route coverage"
+```
+
+## Final Verification
+
+- [ ] Run: `cd backend && uv run pytest tests/unit/config/test_ci_workflow.py --no-cov -q`
+- [ ] Run: `cd frontend && pnpm lint`
+- [ ] Run: `cd frontend && pnpm type-check`
+- [ ] Run: `cd frontend && pnpm type-check:e2e`
+- [ ] Run: `cd frontend && pnpm format:check`
+- [ ] Run: `cd frontend && pnpm vitest run src/routes/__tests__/perspective.test.ts src/__tests__/app-view-provider.test.ts src/hooks/__tests__/useAnalytics.test.ts src/hooks/__tests__/useAssetAnalytics.test.ts src/hooks/__tests__/useAssets.test.ts src/hooks/__tests__/useProject.test.ts src/components/Layout/__tests__/AppBreadcrumb.test.tsx src/components/Layout/__tests__/AppSidebar.test.tsx src/config/__tests__/menuConfig.perspective-grouping.test.tsx src/config/__tests__/rental-retired-navigation.test.ts src/pages/Assets/__tests__/AssetListPage.test.tsx src/pages/Assets/__tests__/AssetDetailPage.test.tsx src/pages/Assets/__tests__/AssetCreatePage.test.tsx src/pages/Assets/__tests__/AssetAnalyticsPage.test.tsx src/components/Project/__tests__/ProjectList.test.tsx src/pages/Project/__tests__/ProjectDetailPage.test.tsx`
+- [ ] Run: `cd frontend && BASE_URL=http://127.0.0.1:5173 VITE_API_BASE_URL=http://127.0.0.1:8002/api/v1 E2E_ADMIN_USERNAME=admin E2E_ADMIN_PASSWORD='Admin123!@#' E2E_REQUIRE_AUTH_STATE=true pnpm playwright test tests/e2e/asset-flow.spec.ts tests/e2e/user/property-certificate-import-success.spec.ts tests/e2e/user/user-usability.spec.ts tests/e2e/user/import-guardrails.spec.ts --project=chromium`
+- [ ] Update `CHANGELOG.md` with the implementation evidence and move this plan to archive once all tasks are complete.
+
+## Exit Criteria
+
+- no runtime import of `ViewContext` remains in production code
+- internal navigation no longer targets shared legacy `/assets/list`, `/project`, `/property-certificates`
+- owner/manager perspective is resolved solely from canonical route prefixes
+- targeted unit/E2E suites pass against canonical active paths
+- any remaining legacy redirects are explicit, bounded, and removable in a subsequent cleanup pass

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -10,6 +10,7 @@
 |------|------|------|------|
 | [2026-02-11-approval-flowable-b-plan.md](2026-02-11-approval-flowable-b-plan.md) | Flowable 编排内核 B 方案 | ⏸ 搁置 | 审批流方向待定，暂不实施 |
 | [2026-03-02-party-scope-isolation-fix-plan.md](2026-03-02-party-scope-isolation-fix-plan.md) | 组织数据权限隔离修复（全量排查） | 🔄 待执行 | Party 列表等集合接口作用域收敛缺失 |
+| [2026-03-22-perspective-simplification-v2-follow-up.md](2026-03-22-perspective-simplification-v2-follow-up.md) | 前端视角简化 v2 后续收口 | 📋 待评审 | 以路由前缀替代 ViewContext/本地选择存储，完成 owner/manager 规范化 |
 | [2026-03-21-ci-baseline-restoration-plan.md](2026-03-21-ci-baseline-restoration-plan.md) | CI 基线恢复与格式治理 | 📋 待评审 | 独立修复 Trivy action 失效与 backend/frontend 现有格式红灯，不与业务 PR 混改 |
 
 ## 已归档方案


### PR DESCRIPTION
## Summary
- upgrade first-party GitHub Actions and Codecov workflow dependencies to Node 24-compatible major versions across `ci.yml`, `security.yml`, and `quality-trends.yml` while keeping the job toolchain Node version at 20
- add a workflow regression guard so CI fails if these workflows pin deprecated Node 20 action majors again
- add a new follow-up implementation plan for frontend perspective simplification v2 under `docs/plans/`

## Test Plan
- cd backend && uv run pytest tests/unit/config/test_ci_workflow.py --no-cov -q
- make docs-lint
- rg -n "actions/(checkout|setup-node|setup-python|cache|upload-artifact)@v4|codecov/codecov-action@v4" .github/workflows

## Notes
- The new plan document is intentionally scoped to frontend route-derived perspective cleanup only; it does not reopen backend authz redesign.
- Workflow runtime warnings were based on the official GitHub deprecation notice for Node 20 JavaScript actions and the current official action release lines.
